### PR TITLE
Authentication is against first user in MongoDB even if email does not match

### DIFF
--- a/lib/strategies/local.js
+++ b/lib/strategies/local.js
@@ -1,9 +1,10 @@
 var passport = require('passport');
 
 exports.callback = function (email, password, done) { 
-    exports.User.findOrCreate({
-        email: email,
-        password: password
+    exports.User.findOne({
+        where: {
+            email: email
+        }
     }, function (err, user) {
         if (err) {
             return done(err);

--- a/lib/user.js
+++ b/lib/user.js
@@ -46,18 +46,6 @@ exports.findOrCreate = function (data, done) {
         });
     } else
 
-    /* LOCAL */
-    if (data.email) {
-        User.all({
-            where: {
-                email: data.email
-            }, limit: 1
-        }, function (err, user) {
-            if (user[0]) return done(err, user[0]);
-            if (!user[0]) return done(err);
-        });
-    } else
-
     /* SOMETHING NOT KNOWN YET */
     {
         console.log(data.profile);
@@ -74,4 +62,3 @@ exports.findOrCreate = function (data, done) {
  *     property('linkedinId', String, { index: true });
  * });
  */
-


### PR DESCRIPTION
I'm using CompoundJS with MongoDB with the local strategy.  The way the code for compound-password is written, it adopts the default findOrCreate method on User from the CompoundJS framework, although it provides a shim in user.js.  findOrCreate accepts a query such as {where: {email: "foo@bar.com"}}.  It just so happens that if the query omits the "where" as in {email:"foo@bar.com}, it matches the first entry in the User collection.  This is the way the local strategy is written right now.

Thus it always authenticates against the first user in the User collection regardless of email.

I'm trying to figure out the right way to fix this.
