### PR TITLE
failureFlash should have a message associated with it

### DIFF
--- a/lib/strategies/local.js
+++ b/lib/strategies/local.js
@@ -36,7 +36,7 @@ exports.init = function (conf, app) {
 
     app.post('/login', passport.authenticate('local', {
         failureRedirect: '/login',
-        failureFlash: true
+        failureFlash: conf.failureFlash
     }), exports.redirectOnSuccess);
 
 };


### PR DESCRIPTION
Need to return done(null, false, {message: 'something...'}); or set failureFlash: 'something...', so I chose the latter.
