### PR TITLE
Separation of config from code through eval of process.env when present in yml config

### DIFF
--- a/lib/passport.js
+++ b/lib/passport.js
@@ -26,12 +26,17 @@ require('fs').readdirSync(stratDir).forEach(function (file) {
 //  Helper regexp and function for reading apiKey/secret from process.env
 var processEnvRegexp = /^process\.env\.(\w+)$/;
 var evalProcessEnvIfNeeded = function(value) {
-    if(!value
-        || !processEnvRegexp.test(value)) {
+    if(!value) {
         return value;
-    } else {
-        return eval(value);
     }
+
+    var results = value.match(processEnvRegexp);
+    if(!results
+        || results.length != 2) {
+        return value;
+    }
+
+    return process.env[results[1]];
 }
 
 exports.init = function (compound) {


### PR DESCRIPTION
I separated config from code by eval-ing all apiKey and secret config entries that match process.env.SOME_ENV_VARIABLE.
