### PR TITLE
Configurable Facebook authentication scope

### DIFF
--- a/lib/strategies/facebook.js
+++ b/lib/strategies/facebook.js
@@ -18,7 +18,7 @@ exports.init = function (conf, app) {
     }, exports.callback));
 
     app.get('/auth/facebook',
-        passport.authenticate('facebook', { scope: [ 'email' ] }));
+        passport.authenticate('facebook', { scope: conf.facebook.scope ? conf.facebook.scope.split(' ') : [ 'email' ] }));
 
     app.get('/auth/facebook/callback',
         passport.authenticate('facebook', {


### PR DESCRIPTION
Instead of hard-coded 'email' scope, you can now configured the scope in passport.yml like this:

```
development:
  ...
  facebook:
    apiKey: <your FB app key>
    secret: <your FB secret>
    scope: <the FB scope of your app>
```

For example, scope could be "email user_photos".
