### PR TITLE
Solved a silent overwriting of app's auth controller

### DIFF
--- a/lib/passport.js
+++ b/lib/passport.js
@@ -90,16 +90,15 @@ exports.init = function (compound) {
     });
 
     compound.on('structure', function(s) {
-        s.controllers.auth = function AuthController() {
+        //  Use __compoundPassportAuth to avoid polluting controllers namespace.
+        s.controllers.__compoundPassportAuth = function CompoundPassportAuthController() {
             this.__missingAction = function (c) {
                 c.next();
             };
         };
     });
 
-    app.get('/auth/:idp/*', function (req, res) {
-        res.send('Provider `' + req.params.idp + '` is not enabled. Specify appropriated settings in config/passport.yml file');
-    });
+    //  For auth/* routes that aren't enabled leave the application to handle 404.
 
     // convert user to userId
     passport.serializeUser(function serializeUser(user, done) {


### PR DESCRIPTION
In production (without 'watch' enabled) my `auth` controller wasn't working. I traced the issue to this module - it was overwriting controllers.auth without checking for any existence. To remove any possible conflict I renamed the compound-passport's controller to __compoundPassportAuth - something very unlikely to be used in production.

I also removed the default routing of /auth to leave app to handle the 404s. Otherwise all unknown /auth/\* paths display a message internal to this module.
