### PR TITLE
Compound-passport google oauth 2

### DIFF
--- a/lib/strategies/google_oauth.js
+++ b/lib/strategies/google_oauth.js
@@ -5,17 +5,14 @@ exports.callback = function (request, accessToken, refreshToken, profile, done) 
         request: request,
         accessToken: accessToken,
         refreshToken: refreshToken,
-        profile: profile, 
-        done: function (err, user) {
-            done(err, user);
-        }
+        profile: profile
+    }, function (err, user) {
+        done(err, user);
     });
 };
 
 exports.init = function (conf, app) {
-    console.log("this strategy is being called from bryan github v 3");
-    console.log(JSON.stringify(conf));
-    console.log(conf.google_oauth.clientID);
+    console.log("this strategy is being called from bryan github v 4");
     var Strategy = require('passport-google-oauth').OAuth2Strategy;
     passport.use(new Strategy({
           clientID: conf.google_oauth.clientID,

--- a/lib/strategies/google_oauth.js
+++ b/lib/strategies/google_oauth.js
@@ -5,10 +5,10 @@ exports.callback = function (request, accessToken, refreshToken, profile, done) 
         request: request,
         accessToken: accessToken,
         refreshToken: refreshToken,
-        profile: profile
-    }, function (err, user) {
-        done(err, user);
-    });
+        profile: profile, 
+        function (err, user) {
+            done(err, user);
+        });
 };
 
 exports.init = function (conf, app) {

--- a/lib/strategies/google_oauth.js
+++ b/lib/strategies/google_oauth.js
@@ -1,0 +1,27 @@
+var passport = require('passport');
+
+exports.callback = function (identifier, profile, done) {
+    exports.User.findOrCreate({
+        openId: identifier,
+        profile: profile
+    }, function (err, user) {
+        done(err, user);
+    });
+};
+
+exports.init = function (conf, app) {
+    console.log("this strategy is being called from bryan github");
+    console.log(JSON.stringify(conf));
+    var Strategy = require('passport-google').Strategy;
+    passport.use(new Strategy({
+        returnURL: conf.baseURL + 'auth/google/return',
+        realm: conf.baseURL
+    }, exports.callback));
+
+    app.get('/auth/google',
+        passport.authenticate('google'));
+    app.get('/auth/google/return',
+        passport.authenticate('google', { failureRedirect: '/' }),
+        exports.redirectOnSuccess);
+};
+

--- a/lib/strategies/google_oauth.js
+++ b/lib/strategies/google_oauth.js
@@ -12,6 +12,7 @@ exports.callback = function (identifier, profile, done) {
 exports.init = function (conf, app) {
     console.log("this strategy is being called from bryan github v 3");
     console.log(JSON.stringify(conf));
+    console.log(conf.google_oauth.clientID);
     var Strategy = require('passport-google-oauth').Strategy;
     passport.use(new Strategy({
           clientID: conf.google_oauth.clientID,

--- a/lib/strategies/google_oauth.js
+++ b/lib/strategies/google_oauth.js
@@ -10,13 +10,13 @@ exports.callback = function (identifier, profile, done) {
 };
 
 exports.init = function (conf, app) {
-    console.log("this strategy is being called from bryan github");
+    console.log("this strategy is being called from bryan github v 3");
     console.log(JSON.stringify(conf));
     var Strategy = require('passport-google-oauth').Strategy;
     passport.use(new Strategy({
           clientID: conf.google_oauth.clientID,
           clientSecret: conf.google_oauth.secret,
-          callbackURL: conf.baseURL + 'auth/google/callback'
+          callbackURL: conf.ssl_base + 'auth/google/callback'
     }, exports.callback));
 
     app.get('/auth/google',

--- a/lib/strategies/google_oauth.js
+++ b/lib/strategies/google_oauth.js
@@ -8,7 +8,8 @@ exports.callback = function (request, accessToken, refreshToken, profile, done) 
         profile: profile, 
         done: function (err, user) {
             done(err, user);
-        });
+        }
+    });
 };
 
 exports.init = function (conf, app) {

--- a/lib/strategies/google_oauth.js
+++ b/lib/strategies/google_oauth.js
@@ -21,7 +21,7 @@ exports.init = function (conf, app) {
 
     app.get('/auth/google',
         passport.authenticate('google_oauth'));
-    app.get('auth/google/callback',
+    app.get('/auth/google/callback',
         passport.authenticate('google_oauth', { failureRedirect: '/' }),
         exports.redirectOnSuccess);
 };

--- a/lib/strategies/google_oauth.js
+++ b/lib/strategies/google_oauth.js
@@ -1,8 +1,10 @@
 var passport = require('passport');
 
-exports.callback = function (identifier, profile, done) {
+exports.callback = function (request, accessToken, refreshToken, profile, done) {
     exports.User.findOrCreate({
-        openId: identifier,
+        request: request,
+        accessToken: accessToken,
+        refreshToken: refreshToken,
         profile: profile
     }, function (err, user) {
         done(err, user);
@@ -17,13 +19,14 @@ exports.init = function (conf, app) {
     passport.use(new Strategy({
           clientID: conf.google_oauth.clientID,
           clientSecret: conf.google_oauth.secret,
+          passReqToCallback   : true,
           callbackURL: conf.ssl_base + 'auth/google/callback'
     }, exports.callback));
 
     app.get('/auth/google',
-        passport.authenticate('google_oauth'));
+        passport.authenticate('google', {scope: conf.google_oauth.scope}));
     app.get('/auth/google/callback',
-        passport.authenticate('google_oauth', { failureRedirect: '/' }),
+        passport.authenticate('google', {failureRedirect: '/' }),
         exports.redirectOnSuccess);
 };
 

--- a/lib/strategies/google_oauth.js
+++ b/lib/strategies/google_oauth.js
@@ -6,7 +6,7 @@ exports.callback = function (request, accessToken, refreshToken, profile, done) 
         accessToken: accessToken,
         refreshToken: refreshToken,
         profile: profile, 
-        function (err, user) {
+        done: function (err, user) {
             done(err, user);
         });
 };

--- a/lib/strategies/google_oauth.js
+++ b/lib/strategies/google_oauth.js
@@ -12,16 +12,17 @@ exports.callback = function (identifier, profile, done) {
 exports.init = function (conf, app) {
     console.log("this strategy is being called from bryan github");
     console.log(JSON.stringify(conf));
-    var Strategy = require('passport-google').Strategy;
+    var Strategy = require('passport-google-oauth').Strategy;
     passport.use(new Strategy({
-        returnURL: conf.baseURL + 'auth/google/return',
-        realm: conf.baseURL
+          clientID: conf.google_oauth.clientID,
+          clientSecret: conf.google_oauth.secret,
+          callbackURL: conf.baseURL + 'auth/google/callback'
     }, exports.callback));
 
     app.get('/auth/google',
-        passport.authenticate('google'));
-    app.get('/auth/google/return',
-        passport.authenticate('google', { failureRedirect: '/' }),
+        passport.authenticate('google_oauth'));
+    app.get('auth/google/callback',
+        passport.authenticate('google_oauth', { failureRedirect: '/' }),
         exports.redirectOnSuccess);
 };
 

--- a/lib/strategies/google_oauth.js
+++ b/lib/strategies/google_oauth.js
@@ -12,7 +12,6 @@ exports.callback = function (request, accessToken, refreshToken, profile, done) 
 };
 
 exports.init = function (conf, app) {
-    console.log("this strategy is being called from bryan github v 4");
     var Strategy = require('passport-google-oauth').OAuth2Strategy;
     passport.use(new Strategy({
           clientID: conf.google_oauth.clientID,

--- a/lib/strategies/google_oauth.js
+++ b/lib/strategies/google_oauth.js
@@ -13,7 +13,7 @@ exports.init = function (conf, app) {
     console.log("this strategy is being called from bryan github v 3");
     console.log(JSON.stringify(conf));
     console.log(conf.google_oauth.clientID);
-    var Strategy = require('passport-google-oauth').Strategy;
+    var Strategy = require('passport-google-oauth').OAuth2Strategy;
     passport.use(new Strategy({
           clientID: conf.google_oauth.clientID,
           clientSecret: conf.google_oauth.secret,


### PR DESCRIPTION
Since google is shutting down openid support and older versions of oauth I needed to make oauth 2 work for my site. Had some troubles understanding the done function and how to structure my user.js but I finally got it working, I decided that in case someone still wanted to use the older google library for a while longer I would name mine google_oauth but that can be changed if it seems unlikely, this is also why I have made some changes to passport yml needs

The passport yml would look like 
development:
  baseURL: 'http://localhost/'
  ssl_base: 'https://localhost/'
  google_oauth:
    clientID: client id goes here
    secret: secret goes here 
    scope: space separated list of scope goes here, I just used "email"
